### PR TITLE
feat: prepare v0.9.0 fork

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -1,5 +1,5 @@
 Jvmtop - java monitoring for the command-line.
-https://github.com/patric-r/jvmtop
+https://github.com/MOschIT/jvmtop
 
 Installation
 ------------
@@ -17,4 +17,4 @@ For all options of jvmtop, pass the --help argument.
 
 For more information and the documentation, visit the project's homepage:
 
-https://github.com/patric-r/jvmtop
+https://github.com/MOschIT/jvmtop

--- a/README.md
+++ b/README.md
@@ -1,21 +1,28 @@
 <b>jvmtop</b> is a lightweight console application to monitor all accessible, running jvms on a machine.<br>
-In a top-like manner, it displays <a href='https://github.com/patric-r/jvmtop/blob/master/doc/ExampleOutput.md'>JVM internal metrics</a> (e.g. memory information) of running java processes.<br>
+In a top-like manner, it displays <a href='https://github.com/MOschIT/jvmtop/blob/master/doc/ExampleOutput.md'>JVM internal metrics</a> (e.g. memory information) of running java processes.<br>
 <br>
-Jvmtop does also include a <a href='https://github.com/patric-r/jvmtop/blob/master/doc/ConsoleProfiler.md'>CPU console profiler</a>.<br>
+Jvmtop does also include a <a href='https://github.com/MOschIT/jvmtop/blob/master/doc/ConsoleProfiler.md'>CPU console profiler</a>.<br>
 <br>
 It's tested with different releases of Oracle JDK, IBM JDK and OpenJDK on Linux, Solaris, FreeBSD and Windows hosts.<br>
 Jvmtop requires a JDK - a JRE will not suffice.<br>
 <br>
 Please note that it's currently in an alpha state -<br>
-if you experience an issue or need further help, please <a href='https://github.com/patric-r/jvmtop/issues'>let us know</a>.<br>
+if you experience an issue or need further help, please <a href='https://github.com/MOschIT/jvmtop/issues'>let us know</a>.<br>
 <br>
-Jvmtop is open-source. Checkout the <a href='https://github.com/patric-r/jvmtop'>source code</a>. Patches are very welcome!<br>
+Jvmtop is open-source. Checkout the <a href='https://github.com/MOschIT/jvmtop'>source code</a>. Patches are very welcome!<br>
 <br>
-Also have a look at the <a href='https://github.com/patric-r/jvmtop/blob/master/doc/Documentation.md'>documentation</a> or at a <a href='https://github.com/patric-r/jvmtop/blob/master/doc/ExampleOutput.md'>captured live-example</a>.<br>
+Also have a look at the <a href='https://github.com/MOschIT/jvmtop/blob/master/doc/Documentation.md'>documentation</a> or at a <a href='https://github.com/MOschIT/jvmtop/blob/master/doc/ExampleOutput.md'>captured live-example</a>.<br>
+
+<hr />
+
+<h3>About this fork</h3>
+This project is a fork of <a href='https://github.com/patric-r/jvmtop'>jvmtop</a> by Patric Rufflar, starting at version 0.8.0.<br>
+The original code is licensed under the <a href='https://www.gnu.org/licenses/old-licenses/gpl-2.0.html'>GNU General Public License v2.0</a>.<br>
+This fork is also licensed under the GPL v2.0.
 
 ```
  JvmTop 0.8.0 alpha   amd64  8 cpus, Linux 2.6.32-27, load avg 0.12
- https://github.com/patric-r/jvmtop
+ https://github.com/MOschIT/jvmtop
 
   PID MAIN-CLASS      HPCUR HPMAX NHCUR NHMAX    CPU     GC    VM USERNAME   #T DL
  3370 rapperSimpleApp  165m  455m  109m  176m  0.12%  0.00% S6U37 web        21
@@ -28,9 +35,28 @@ Also have a look at the <a href='https://github.com/patric-r/jvmtop/blob/master/
 <hr />
 
 <h3>Installation</h3>
-Click on the <a href="https://github.com/patric-r/jvmtop/releases"> releases tab</a>, download the
+Click on the <a href="https://github.com/MOschIT/jvmtop/releases"> releases tab</a>, download the
 most recent tar.gz archive. Extract it, ensure that the `JAVA_HOME` environment variable points to a valid JDK and run `./jvmtop.sh`.<br><br>
-Further information can be found in the [INSTALL file](https://github.com/patric-r/jvmtop/blob/master/INSTALL)
+Further information can be found in the [INSTALL file](https://github.com/MOschIT/jvmtop/blob/master/INSTALL)
+
+<hr />
+
+<h3>Building from source</h3>
+Requires JDK 21+ and Maven.
+
+<pre><code>./build.sh</code></pre>
+
+This produces <code>target/jvmtop-0.9.0-SNAPSHOT.jar</code> and copies dependencies into <code>target/lib/</code>.
+
+<h4>Running on JDK 9+</h4>
+Jvmtop uses internal JDK APIs (<code>sun.jvmstat.monitor</code>, <code>jdk.internal.agent</code>, etc.)
+that are encapsulated starting with JDK 9. You must pass <code>--add-opens</code> flags at runtime:
+
+<pre><code>java --add-opens=jdk.internal.jvmstat/sun.jvmstat.monitor=ALL-UNNAMED \
+     --add-opens=jdk.management.agent/jdk.internal.agent=ALL-UNNAMED \
+     --add-opens=java.rmi/sun.rmi.server=ALL-UNNAMED \
+     --add-opens=java.rmi/sun.rmi.transport=ALL-UNNAMED \
+     -jar target/jvmtop-0.9.0-SNAPSHOT.jar</code></pre>
 
 
 
@@ -39,21 +65,21 @@ Further information can be found in the [INSTALL file](https://github.com/patric
 <ul><li>improved attach compatibility for all IBM jvms<br>
 </li><li>fixed wrong CPU/GC values for IBM J9 jvms<br>
 </li><li>in case of unsupported heap size metric retrieval, n/a will be displayed instead of 0m<br>
-</li><li>improved argument parsing, support for short-options, added help (pass <code>--help</code>), see <a href='https://github.com/patric-r/jvmtop/issues/28'>issue #28</a> (now using the great <a href='http://pholser.github.io/jopt-simple'>jopt-simple</a> library)<br>
-</li><li>when passing the <code>--once</code> option, terminal will not be cleared anymore (see <a href='https://github.com/patric-r/jvmtop/issues/27'>issue #27</a>)<br>
+</li><li>improved argument parsing, support for short-options, added help (pass <code>--help</code>), see <a href='https://github.com/MOschIT/jvmtop/issues/28'>issue #28</a> (now using the great <a href='http://pholser.github.io/jopt-simple'>jopt-simple</a> library)<br>
+</li><li>when passing the <code>--once</code> option, terminal will not be cleared anymore (see <a href='https://github.com/MOschIT/jvmtop/issues/27'>issue #27</a>)<br>
 </li><li>improved shell script for guessing the path if a <code>JAVA_HOME</code> environment variable is not present (thanks to <a href='https://groups.google.com/forum/#!topic/jvmtop-discuss/KGg_WpL_yAU'>Markus Kolb</a>)</li></ul>
 
-<a href='https://github.com/patric-r/jvmtop/blob/master/doc/Changelog.md'>Full changelog</a>
+<a href='https://github.com/MOschIT/jvmtop/blob/master/doc/Changelog.md'>Full changelog</a>
 
 <hr />
 
-In <a href='https://github.com/patric-r/jvmtop/blob/master/doc/ExampleOutput.md'>VM detail mode</a> it shows you the top CPU-consuming threads, beside detailed metrics:<br>
+In <a href='https://github.com/MOschIT/jvmtop/blob/master/doc/ExampleOutput.md'>VM detail mode</a> it shows you the top CPU-consuming threads, beside detailed metrics:<br>
 <br>
 <br>
 
 ```
  JvmTop 0.8.0 alpha   amd64,  4 cpus, Linux 2.6.18-34
- https://github.com/patric-r/jvmtop
+ https://github.com/MOschIT/jvmtop
 
  PID 3539: org.apache.catalina.startup.Bootstrap
  ARGS: start
@@ -71,5 +97,5 @@ In <a href='https://github.com/patric-r/jvmtop/blob/master/doc/ExampleOutput.md'
  128026 JMX server connection timeout   TIMED_WAITING  0.00%     0.00%
 ```
 
-<a href='https://github.com/patric-r/jvmtop/issues'>Pull requests / bug reports</a> are always welcome.<br>
+<a href='https://github.com/MOschIT/jvmtop/issues'>Pull requests / bug reports</a> are always welcome.<br>
 <br>

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -e
+
+cd "$(dirname "$0")"
+
+echo "Building jvmtop..."
+mvn clean package
+
+JAR="target/jvmtop-0.9.0-SNAPSHOT.jar"
+LIB="target/lib"
+
+if [ -f "$JAR" ] && [ -d "$LIB" ]; then
+  echo "Build successful."
+  echo "JAR: $JAR"
+  echo "Dependencies: $LIB/"
+  echo ""
+  echo "Run with:"
+  echo "  java --add-opens=jdk.internal.jvmstat/sun.jvmstat.monitor=ALL-UNNAMED \\"
+  echo "       --add-opens=jdk.management.agent/jdk.internal.agent=ALL-UNNAMED \\"
+  echo "       --add-opens=java.rmi/sun.rmi.server=ALL-UNNAMED \\"
+  echo "       --add-opens=java.rmi/sun.rmi.transport=ALL-UNNAMED \\"
+  echo "       -jar $JAR"
+else
+  echo "Build failed: JAR or lib directory not found."
+  exit 1
+fi

--- a/doc/ConsoleProfiler.md
+++ b/doc/ConsoleProfiler.md
@@ -12,7 +12,7 @@ jvmtop.sh --profile <PID>
 # Example output #
 ```
  JvmTop 0.7.0 alpha - 15:16:34,  amd64,  8 cpus, Linux 2.6.32-27, load avg 0.41
- https://github.com/patric-r/jvmtop
+ https://github.com/MOschIT/jvmtop
 
  Profiling PID 24015: org.apache.catalina.startup.Bootstrap
 

--- a/doc/Documentation.md
+++ b/doc/Documentation.md
@@ -36,7 +36,7 @@ Command-line: `jvmtop.sh`
 
 ```
  JvmTop 0.4.1 alpha   amd64  8 cpus, Linux 2.6.32-27, load avg 0.12
- https://github.com/patric-r/jvmtop
+ https://github.com/MOschIT/jvmtop
 
   PID MAIN-CLASS      HPCUR HPMAX NHCUR NHMAX    CPU     GC    VM USERNAME   #T DL
  3370 rapperSimpleApp  165m  455m  109m  176m  0.12%  0.00% S6U37 web        21
@@ -71,7 +71,7 @@ Command-line:  `jvmtop.sh <pid>`
 
 ```
  JvmTop 0.4.1 alpha   amd64,  4 cpus, Linux 2.6.18-34
- https://github.com/patric-r/jvmtop
+ https://github.com/MOschIT/jvmtop
 
  PID 3539: org.apache.catalina.startup.Bootstrap
  ARGS: start

--- a/doc/ExampleOutput.md
+++ b/doc/ExampleOutput.md
@@ -27,7 +27,7 @@ Command-line:  <code>jvmtop.sh &lt;pid&gt;</code>
 
 
 <pre><code> JvmTop 0.4.1 alpha   amd64,  4 cpus, Linux 2.6.18-34<br>
- https://github.com/patric-r/jvmtop<br>
+ https://github.com/MOschIT/jvmtop<br>
 <br>
  PID 3539: org.apache.catalina.startup.Bootstrap<br>
  ARGS: start<br>

--- a/pom.xml
+++ b/pom.xml
@@ -7,6 +7,33 @@
     <groupId>com.jvmtop</groupId>
     <artifactId>jvmtop</artifactId>
     <version>0.9.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <name>jvmtop</name>
+    <description>Java monitoring for the command-line. Forked from https://github.com/patric-r/jvmtop at v0.8.0.</description>
+    <url>https://github.com/MOschIT/jvmtop</url>
+
+    <licenses>
+        <license>
+            <name>GNU General Public License v2.0</name>
+            <url>https://www.gnu.org/licenses/old-licenses/gpl-2.0.html</url>
+        </license>
+    </licenses>
+
+    <developers>
+        <developer>
+            <name>Patric Rufflar</name>
+            <roles>
+                <role>Original Author</role>
+            </roles>
+        </developer>
+        <developer>
+            <name>MOschIT</name>
+            <roles>
+                <role>Maintainer</role>
+            </roles>
+        </developer>
+    </developers>
 
     <dependencies>
         <dependency>

--- a/src/main/java/com/jvmtop/JvmTop.java
+++ b/src/main/java/com/jvmtop/JvmTop.java
@@ -4,6 +4,8 @@
  * Copyright (C) 2013 by Patric Rufflar. All rights reserved. DO NOT ALTER OR REMOVE COPYRIGHT
  * NOTICES OR THIS FILE HEADER.
  *
+ * Modified by MOschIT (fork at v0.8.0, released as v0.9.0).
+ *
  *
  * This code is free software; you can redistribute it and/or modify it under the terms of the GNU
  * General Public License version 2 only, as published by the Free Software Foundation.
@@ -48,7 +50,7 @@ import com.jvmtop.view.VMProfileView;
  */
 public class JvmTop {
 
-	public static final String VERSION = "0.8.0 alpha";
+	public static final String VERSION = "0.9.0";
 
 	private Double delay_ = 1.0;
 
@@ -307,7 +309,7 @@ public class JvmTop {
 		} else {
 			System.out.println();
 		}
-		System.out.println(" https://github.com/patric-r/jvmtop");
+		System.out.println(" https://github.com/MOschIT/jvmtop");
 		System.out.println();
 	}
 


### PR DESCRIPTION
- Forked from patric-r/jvmtop at v0.8.0
- Updated version to 0.9.0
- Updated GitHub URLs to MOschIT/jvmtop
- Added GPLv2 compliance metadata (license, developers, fork notice)
- Added build.sh for Maven builds
- Documented required --add-opens flags for JDK 9+